### PR TITLE
Balance HTML closing and opening tags

### DIFF
--- a/locales/es/categories.po
+++ b/locales/es/categories.po
@@ -12,19 +12,19 @@ msgid "bakery"
 msgstr "Panader&iacute;a"
 
 msgid "dairy"
-msgstr "Fruta"
+msgstr "L&aacute;cteo"
 
 msgid "dry_goods"
-msgstr "de Bienes Seca"
+msgstr "Bienes secos"
 
 msgid "fruit_and_veg"
-msgstr "L&aacute;ctea & Charcuter&iacute;a"
+msgstr "Vegetales & de fruta"
 
 msgid "meat_and_deli"
-msgstr "de Carne & de los Vegetales"
+msgstr "Charcuter&iacute;a & de carne"
 
 msgid "null"
 msgstr "Otro"
 
 msgid "oil_and_vinegar_and_condiments"
-msgstr "Vinagre de Aceite y Condimentos"
+msgstr "Vinagre de aceite y Condimentos"

--- a/locales/es/navigation.po
+++ b/locales/es/navigation.po
@@ -12,10 +12,10 @@ msgid "search"
 msgstr "B&uacute;squeda de receta"
 
 msgid "starred"
-msgstr "Protagoniz&oacute; Comida"
+msgstr "Protagoniz&oacute; Recetas"
 
 msgid "meal-planner"
-msgstr "de Recetas Planner"
+msgstr "Comida Planner"
 
 msgid "shopping-list"
-msgstr "Lista de Compra"
+msgstr "Lista de compra"

--- a/locales/es/search.po
+++ b/locales/es/search.po
@@ -20,7 +20,7 @@ msgid "prompt-additional-options"
 msgstr "Opciones de b&uacute;squeda adicional"
 
 msgid "prompt-exclude"
-msgstr "Son all&iacute; cualesquier ingredientes no <strong>te gustar&iacute;a</strong> cocinar con?"
+msgstr "Es all&iacute; cualesquier ingredientes no <strong>te gustar&iacute;a</strong> cocinar con?"
 
 msgid "prompt-equipment"
 msgstr "Es all&iacute; cualquier equipamiento de cocina te gustar&iacute;a utilizar?"

--- a/locales/fr/categories.po
+++ b/locales/fr/categories.po
@@ -12,19 +12,19 @@ msgid "bakery"
 msgstr "Boulangerie"
 
 msgid "dairy"
-msgstr "Fruit"
+msgstr "L&aacute;cteo"
 
 msgid "dry_goods"
-msgstr "de Biens S&egrave;che"
+msgstr "Biens secs"
 
 msgid "fruit_and_veg"
-msgstr "L&aacute;ctea & Charcuter&iacute;a"
+msgstr "V&eacute;g&eacute;taux & de fruit"
 
 msgid "meat_and_deli"
-msgstr "de Viande & des V&eacute;g&eacute;taux"
+msgstr "Charcuter&iacute;a & De viande"
 
 msgid "null"
-msgstr "Un autre"
+msgstr "Autrui"
 
 msgid "oil_and_vinegar_and_condiments"
-msgstr "Vinaigre d'Huile et Condimentos"
+msgstr "Vinaigre d'huile et Condimentos"

--- a/locales/fr/navigation.po
+++ b/locales/fr/navigation.po
@@ -12,10 +12,10 @@ msgid "search"
 msgstr "Recherche de recette"
 
 msgid "starred"
-msgstr "a Jou&eacute; le r&ocirc;le principal Mang&eacute;e"
+msgstr "Il a jou&eacute; le r&ocirc;le principal des Recettes"
 
 msgid "meal-planner"
-msgstr "de Recettes Planner"
+msgstr "Repas Planner"
 
 msgid "shopping-list"
-msgstr "Liste d'Achat"
+msgstr "Liste d'achat"

--- a/locales/fr/search.po
+++ b/locales/fr/search.po
@@ -20,7 +20,7 @@ msgid "prompt-additional-options"
 msgstr "Options de recherche additionnelle"
 
 msgid "prompt-exclude"
-msgstr "Sont l&agrave; n'importe quels ingr&eacute;dients il ne te <strong>plairait pas</strong> cuisiner avec?"
+msgstr "Il est l&agrave; n'importe quels ingr&eacute;dients il ne te <strong>plairait pas</strong> cuisiner avec?"
 
 msgid "prompt-equipment"
 msgstr "Il est l&agrave; n'importe quel &eacute;quipement de cuisine te plairait utiliser?"

--- a/locales/it/categories.po
+++ b/locales/it/categories.po
@@ -12,19 +12,19 @@ msgid "bakery"
 msgstr "Panader&iacute;a"
 
 msgid "dairy"
-msgstr "Frutta"
+msgstr "Latteo"
 
 msgid "dry_goods"
-msgstr "di Beni Asciuti"
+msgstr "Beni asciuti"
 
 msgid "fruit_and_veg"
-msgstr "Lattei & Charcuter&iacute;a"
+msgstr "Vegetali & di frutta"
 
 msgid "meat_and_deli"
-msgstr "di Carne & dei Vegetali"
+msgstr "Charcuter&iacute;a & di carne"
 
 msgid "null"
 msgstr "Altro"
 
 msgid "oil_and_vinegar_and_condiments"
-msgstr "Aceto di Olio e Condimenti"
+msgstr "Aceto di olio e Condimenti"

--- a/locales/it/navigation.po
+++ b/locales/it/navigation.po
@@ -12,10 +12,10 @@ msgid "search"
 msgstr "Ricerca di ricetta"
 
 msgid "starred"
-msgstr "Protagoniz&oacute; Cibo"
+msgstr "Protagoniz&oacute; Ricette"
 
 msgid "meal-planner"
-msgstr "di Ricette Planner"
+msgstr "Cibo Planner"
 
 msgid "shopping-list"
-msgstr "Elenco di Spesa"
+msgstr "Elenco di spesa"

--- a/locales/it/search.po
+++ b/locales/it/search.po
@@ -20,7 +20,7 @@ msgid "prompt-additional-options"
 msgstr "Opzioni di ricerca aggiuntiva"
 
 msgid "prompt-exclude"
-msgstr "Sono l&igrave; qualsiasi ingredienti non <strong>ti piacerebbe</strong> cucinare con?"
+msgstr "&Egrave; l&igrave; qualsiasi ingredienti non <strong>ti piacerebbe</strong> cucinare con?"
 
 msgid "prompt-equipment"
 msgstr "&Egrave; l&igrave; qualsiasi attrezzatura di cucina ti piacerebbe utilizzare?"

--- a/translation-routing.sh
+++ b/translation-routing.sh
@@ -28,8 +28,13 @@ function translate {
         TRANSLATE_CMD="cat --"
     fi
 
+    # Workaround for https://github.com/openculinary/internationalization/issues/5
+    INSERT_TAG_OPEN='s/^msgstr/<\nmsgstr/g'
+    REMOVE_TAG_OPEN='/^<$/d'
+
+
     mkdir -p "locales/${DST_DIR}"
-    cat ${SRC_FILE} | pospell -n - -f -p ${TRANSLATE_CMD} > ${DST_FILE}
+    cat ${SRC_FILE} | sed -e ${INSERT_TAG_OPEN} | pospell -n - -f -p ${TRANSLATE_CMD} | sed -e ${REMOVE_TAG_OPEN} > ${DST_FILE}
 
     correct ${FILENAME} ${DST_DIR}
 }


### PR DESCRIPTION
This workaround inserts HTML tag open characters (less-than symbol, `<`) to balance out the tag close characters inserted by `pospell`.  This helps `apertium` handle the HTML resource content correctly.  It's not an elegant solution but it works for now.

Fixes #5 